### PR TITLE
Fix typo in container registry domain

### DIFF
--- a/infra/infra_release.sh
+++ b/infra/infra_release.sh
@@ -8,7 +8,7 @@ set -ex
 git pull 
 
 # Bump Version 
-# docker run --rm -v "$PWD":/release ghrc.io/infra patch
+# docker run --rm -v "$PWD":/release ghcr.io/infra patch
 version=`cat $PWD/infra/VERSION`
 echo "version: $version"
 


### PR DESCRIPTION
Hi `jimmy1977/dockerfiles`!

This is not an automatic, 🤖-generated PR, as you can check in my [GitHub profile](https://github.com/p-), I work for GitHub and I am part of the [GitHub Security Lab](https://securitylab.github.com/).

While performing a code search for container registry domains we noticed that this repo contains a misspelled domain name.

If a malicious actor were in control of that misspelled domain, they could potentially perform an attack on the software supply chain of this project and/or steal the credentials used to connect to the container registry (depending on how the misspelled domain name of the container registry is used).
Please fix this typo and check your documentation for similar typos.